### PR TITLE
Add custom font color patch

### DIFF
--- a/configs/default-config.txt
+++ b/configs/default-config.txt
@@ -232,6 +232,14 @@
 // Changes the stage ID used on the main menu. Setting this to -1 will lead to
 // default behavior (where the menu stage ID also uses more than one stage ID)
 
+// custom-font-color
+// font-primary
+// font-secondary
+//
+// Changes the colors of most yellow/orange text in the menus to the designated
+// primary & secondary color hex codes
+// hex codes have a period (.) in front, such as: .ff0000 (for red)
+
 // ----------------------------------------------------------------------------
 
 // 'enabled' - Applies the patch
@@ -281,6 +289,9 @@
 	story-fix-missing-w: disabled
 	pause-cooldown: disabled
 	perfect-bonus-completion: disabled
+	custom-font-color: enabled
+	font-primary: .ffff00
+	font-secondary: .ff8000
 }
 
 // Toggles which menu options are accessible.

--- a/src/config/config.cpp
+++ b/src/config/config.cpp
@@ -16,6 +16,33 @@ static mkb::DVDFileInfo config_file_info;
 static char* config_file_buf;
 static char config_file_path[] = "/config.txt";
 
+u32 parse_hex_value(char* value) {
+    u32 parsed_value = 0;
+    for(u8 i=1; i <= 8; i++) { // Only check the first 8 characters after the #
+        if(value[i] == '\0') return parsed_value; // string is done
+        u8 current_val = 0;
+        switch(value[i]) {
+            case '1': current_val = 1; break;
+            case '2': current_val = 2; break;
+            case '3': current_val = 3; break;
+            case '4': current_val = 4; break;
+            case '5': current_val = 5; break;
+            case '6': current_val = 6; break;
+            case '7': current_val = 7; break;
+            case '8': current_val = 8; break;
+            case '9': current_val = 9; break;
+            case 'A': case 'a': current_val = 10; break;
+            case 'B': case 'b': current_val = 11; break;
+            case 'C': case 'c': current_val = 12; break;
+            case 'D': case 'd': current_val = 13; break;
+            case 'E': case 'e': current_val = 14; break;
+            case 'F': case 'f': current_val = 15; break;
+        }
+        parsed_value = parsed_value * 16 + current_val;
+    }
+    return parsed_value;
+}
+
 u16* parse_stageid_list(char* buf, u16* array) {
     buf = mkb::strchr(buf, '\n') + 1;
 
@@ -102,116 +129,6 @@ void parse_menu_option_toggles(char* buf) {
     } while (buf < end_of_section);
 }
 
-static void skip_spaces(char*& p) {
-    while (*p == ' ' || *p == '\t') p++;
-}
-
-static bool parse_csv_ints(char* value, int* out, int count) {
-    char* p = value;
-
-    for (int i = 0; i < count; ++i) {
-        skip_spaces(p);
-
-        // Parse integer
-        out[i] = mkb::atoi(p);
-
-        // Find next comma if more values expected
-        if (i + 1 < count) {
-            p = mkb::strchr(p, ',');
-            if (!p) return false;
-            p++;// skip comma
-        }
-    }
-
-    return true;
-}
-
-
-// Parses W<world>-<stage>
-static bool parse_world_stage_key(const char* key, int& world_idx, int& stage_idx) {
-    if (key == nullptr || key[0] != 'W') return false;
-
-    // world starts after 'W'
-    int w = mkb::atoi(const_cast<char*>(key + 1));
-
-    // find '-'
-    char* dash = mkb::strchr(const_cast<char*>(key), '-');
-    if (!dash) return false;
-
-    // stage starts after '-'
-    int s = mkb::atoi(dash + 1);
-
-    if (w < 1 || w > main::WORLD_COUNT) return false;
-    if (s < 1 || s > main::STAGES_PER_WORLD) return false;
-
-    world_idx = w - 1;
-    stage_idx = s - 1;
-    return true;
-}
-
-
-void parse_story_mode_entries(char* buf) {
-    buf = mkb::strchr(buf, '\n') + 1;
-
-    char* end_of_section = mkb::strchr(buf, '}');
-    char key[64] = {0};
-    char value[128] = {0};
-
-    do {
-        char *key_start, *key_end, *end_of_line;
-        key_start = mkb::strchr(buf, '\t') + 1;
-        key_end = mkb::strchr(buf, ':');
-        MOD_ASSERT_MSG(key_start < key_end,
-                       "Key start after key end, did you start your key with a tab and not spaces?");
-        end_of_line = mkb::strchr(buf, '\n');
-
-        mkb::strncpy(key, key_start, (key_end - key_start));
-        mkb::strncpy(value, key_end + 2, (end_of_line - key_end) - 2);
-
-        int world_idx = 0, stage_idx = 0;
-        MOD_ASSERT_MSG(
-            parse_world_stage_key(key, world_idx, stage_idx),
-            "Invalid story key format (expected W<1-10>-<1-10>)");
-
-        int vals[3] = {0};
-
-        MOD_ASSERT_MSG(
-            parse_csv_ints(value, vals, 3),
-            "Invalid story value format (expected: stage ID, time limit, difficulty)");
-
-        int stage_id_i = vals[0];
-        int time_limit_i = vals[1];
-        int difficulty_i = vals[2];
-
-
-        MOD_ASSERT_MSG(stage_id_i >= 0 && stage_id_i <= 420, "Stage ID out of range (0-420)");
-        MOD_ASSERT_MSG(time_limit_i >= 0 && time_limit_i <= 360, "Time limit out of range (0-360)");
-        MOD_ASSERT_MSG(difficulty_i >= 0 && difficulty_i <= 10, "Difficulty out of range (0-10)");
-
-        main::NewStoryStageEntry& entry =
-            main::new_story_entries[world_idx][stage_idx];
-
-        MOD_ASSERT_MSG(!entry.set, "Duplicate Story Mode entry for same world/stage");
-
-        entry.stage_id = static_cast<u16>(stage_id_i);
-        entry.time_limit = static_cast<u16>(time_limit_i);
-        entry.difficulty = static_cast<u8>(difficulty_i);
-        entry.set = true;
-
-        buf = end_of_line + 1;
-        mkb::memset(key, '\0', sizeof(key));
-        mkb::memset(value, '\0', sizeof(value));
-    } while (buf < end_of_section);
-
-    for (int w = 0; w < main::WORLD_COUNT; ++w) {
-        for (int s = 0; s < main::STAGES_PER_WORLD; ++s) {
-            MOD_ASSERT_MSG(main::new_story_entries[w][s].set, "Missing Story Mode entry");
-        }
-    }
-
-    LOG("Story Mode Entries loaded at: 0x%X", &main::new_story_entries);
-}
-
 void parse_function_toggles(char* buf) {
     // Enters from section parsing, so skip to the next line
     buf = mkb::strchr(buf, '\n') + 1;
@@ -248,7 +165,9 @@ void parse_function_toggles(char* buf) {
 
                 // 'value' is some integer, set the value and initialize the patch if it differs from the default
                 else {
-                    parsed_value = mkb::atoi(value);
+                    if(value[0] == '.') parsed_value = parse_hex_value(value);
+                    else parsed_value = mkb::atoi(value);
+                    //parsed_value = mkb::atoi(value);
 
                     // Only set value on tickables that have a defined default active value
                     if (!tickable->active_value.has_value()) break;
@@ -328,10 +247,6 @@ void parse_config() {
                     else if (STREQ(section, "Music IDs")) {
                         parse_stageid_list(section_end, main::bgm_id_lookup);
                         LOG("Music ID list loaded at: 0x%X", &main::bgm_id_lookup);
-                    }
-
-                    else if (STREQ(section, "Story Mode Entries")) {
-                        parse_story_mode_entries(section_end);
                     }
 
                     else {

--- a/src/patches/custom/font_color.cpp
+++ b/src/patches/custom/font_color.cpp
@@ -1,0 +1,72 @@
+#include "font_color.h"
+
+#include "../internal/patch.h"
+#include "../internal/tickable.h"
+#include "../mkb/mkb.h"
+#include "../utils/ppcutil.h"
+#include "font_primary.h"
+#include "font_secondary.h"
+
+namespace font_color {
+
+TICKABLE_DEFINITION((
+        .name = "custom-font-color",
+        .description = "Font Color",
+        .init_main_loop = init,
+        .init_main_game = init_main_game,))
+
+// void textdraw_set_mul_color(uint param_1);
+static patch::Tramp<decltype(&mkb::textdraw_set_mul_color)> s_textdraw_set_mul_color_tramp;
+
+void replace_lis_color(int reg, u32 loc, u32 color) {
+    patch::write_word(reinterpret_cast<void*>(loc), PPC_INSTR_LIS(reg, (color >> 16) & 0xff));// RR
+    patch::write_word(reinterpret_cast<void*>(loc + 4), PPC_INSTR_ORI(reg, (color & 0xffff)));// GGBB
+}
+
+void replace_3pt_color(u32 loc, u32 color) {
+    patch::write_word(reinterpret_cast<void*>(loc), 0x38000000 + ((color >> 16) & 0xff));   // RR
+    patch::write_word(reinterpret_cast<void*>(loc + 8), 0x38000000 + ((color >> 8) & 0xff));// GG
+    patch::write_word(reinterpret_cast<void*>(loc + 16), 0x38000000 + (color & 0xff));      // BB
+}
+
+u32 form_color(u8 red, u8 blue, u8 green) {
+    return (red << 16) + (blue << 8) + green;
+}
+
+u32 convert_color(u32 color) {
+    u8 red = (color >> 16) & 0xff;
+    u8 green = (color >> 8) & 0xff;
+    u8 blue = color & 0xff;
+    u32 new_color = color;
+    if (blue == 0 && red > 0 && green > 0 && red >= green) {// Orange & yellow (b=0, r>=g>0)
+        u8 red_1 = (font_primary::get_color() >> 16) & 0xff;
+        u8 green_1 = (font_primary::get_color() >> 8) & 0xff;
+        u8 blue_1 = font_primary::get_color() & 0xff;
+        u8 red_2 = (font_secondary::get_color() >> 16) & 0xff;
+        u8 green_2 = (font_secondary::get_color() >> 8) & 0xff;
+        u8 blue_2 = font_secondary::get_color() & 0xff;
+        float percent_primary = (1 - ((float)(red - green) / (red/2)));
+        new_color = form_color((u8)(((float)red/0xff) * ((red_1 * percent_primary) + (red_2 * (1-percent_primary)))),
+                               (u8)(((float)red/0xff) * ((green_1 * percent_primary) + (green_2 * (1-percent_primary)))),
+                               (u8)(((float)red/0xff) * ((blue_1 * percent_primary) + (blue_2 * (1-percent_primary)))));
+    }
+    return new_color;
+}
+
+void init() {
+    patch::hook_function(s_textdraw_set_mul_color_tramp, mkb::textdraw_set_mul_color, [](u32 color) {
+        s_textdraw_set_mul_color_tramp.dest(convert_color(color));
+    });
+}
+
+void init_main_game() {
+    replace_3pt_color(0x80338c84, font_primary::get_color());// Stage number RGB color
+    replace_3pt_color(0x80338e74, font_primary::get_color());// Stage name RGB color
+    replace_3pt_color(0x80338A84, font_primary::get_color());// EX color
+    replace_3pt_color(0x8032caa0, convert_color(0xffc000));// READY text color
+    replace_3pt_color(0x8032d944, font_secondary::get_color());// GO text color
+    replace_3pt_color(0x8032bbb8, font_primary::get_color());// STAGE/WORLD spin in color
+    replace_3pt_color(0x8032E91C, font_secondary::get_color());// FALLOUT color
+}
+
+}// namespace font_color

--- a/src/patches/custom/font_color.h
+++ b/src/patches/custom/font_color.h
@@ -1,0 +1,6 @@
+#pragma once
+
+namespace font_color {
+void init();
+void init_main_game();
+}// namespace font_color

--- a/src/patches/custom/font_primary.cpp
+++ b/src/patches/custom/font_primary.cpp
@@ -1,0 +1,29 @@
+#include "font_primary.h"
+
+#include "../internal/patch.h"
+#include "../internal/tickable.h"
+#include "../mkb/mkb.h"
+#include "../utils/ppcutil.h"
+
+namespace font_primary {
+
+int primary_color = 0xffff00;
+
+// Patch slot holding primary color for font-color
+TICKABLE_DEFINITION((
+        .name = "font-primary",
+        .description = "Font Primary",
+        .active_value = primary_color,
+        .lower_bound = 0x000000,
+        .upper_bound = 0xffffff,
+        .init_main_loop = init,))
+
+int get_color() {
+    return primary_color;
+}
+
+void init() {
+    primary_color = *active_tickable_ptr->active_value;
+}
+
+}// namespace font_primary

--- a/src/patches/custom/font_primary.h
+++ b/src/patches/custom/font_primary.h
@@ -1,0 +1,6 @@
+#pragma once
+
+namespace font_primary {
+    int get_color();
+    void init();
+}// namespace font_primary

--- a/src/patches/custom/font_secondary.cpp
+++ b/src/patches/custom/font_secondary.cpp
@@ -1,0 +1,29 @@
+#include "font_secondary.h"
+
+#include "../internal/patch.h"
+#include "../internal/tickable.h"
+#include "../mkb/mkb.h"
+#include "../utils/ppcutil.h"
+
+namespace font_secondary {
+
+int secondary_color = 0xff8000;
+
+// Patch slot holding secondary color for font-color
+TICKABLE_DEFINITION((
+        .name = "font-secondary",
+        .description = "Font Secondary",
+        .active_value = secondary_color,
+        .lower_bound = 0x000000,
+        .upper_bound = 0xffffff,
+        .init_main_loop = init,))
+
+int get_color() {
+    return secondary_color;
+}
+
+void init() {
+    secondary_color = *active_tickable_ptr->active_value;
+}
+
+}// namespace font_secondary

--- a/src/patches/custom/font_secondary.h
+++ b/src/patches/custom/font_secondary.h
@@ -1,0 +1,6 @@
+#pragma once
+
+namespace font_secondary {
+    int get_color();
+    void init();
+}// namespace font_secondary

--- a/src/utils/ppcutil.h
+++ b/src/utils/ppcutil.h
@@ -13,6 +13,7 @@
 
 #define PPC_INSTR_LI(dest_register, value) (0x38000000 + (((u32) (dest_register)) << 21) + ((u16) value))
 #define PPC_INSTR_LIS(dest_register, value) (0x3C000000 + (((u32) (dest_register)) << 21) + ((u16) value))
+#define PPC_INSTR_ORI(dest_register, value) ((0b011000 << 26) + (((u32) (dest_register)) << 21) + (((u32) (dest_register)) << 16) + ((u16) value))
 
 #define PPC_INSTR_NOP() (0x60000000)
 


### PR DESCRIPTION
3 new options added to the config.txt:

custom-font-color
font-primary
font-secondary

Changes the colors of most yellow/orange text in the menus to the designated primary & secondary color hex codes hex codes have a period (.) in front, such as: .ff0000 (for red)